### PR TITLE
Fix TypeError when there was no response body.

### DIFF
--- a/FuelSDK/rest.py
+++ b/FuelSDK/rest.py
@@ -37,7 +37,7 @@ class ET_Constructor(object):
                 body = response[1]  #and the result in tuple position 1
 
                 # Store the Last Request ID for use with continue
-                if 'RequestID' in body:
+                if body and 'RequestID' in body:
                     self.request_id = body['RequestID']
 
                 if self.code == 200:


### PR DESCRIPTION
This will prevent `TypeError: argument of type 'NoneType' is not iterable` if there was no response body, e.g. when status code was 400 or similar. (In that case `body` will be `None`.)
