### PR TITLE
Allow for client_id and client_secrets in init params

### DIFF
--- a/FuelSDK/client.py
+++ b/FuelSDK/client.py
@@ -49,12 +49,16 @@ class ET_Client(object):
         else:
             config.read('config.python')
 
-        if config.has_option('Web Services', 'clientid'):
+        if(params is not None and 'client_id' in params):
+            self.client_id = params['client_id']
+        elif config.has_option('Web Services', 'clientid'):
             self.client_id = config.get('Web Services', 'clientid')
         elif 'FUELSDK_CLIENT_ID' in os.environ:
             self.client_id = os.environ['FUELSDK_CLIENT_ID']
 
-        if config.has_option('Web Services', 'clientsecret'):
+        if(params is not None and 'client_secret' in params):
+            self.client_secret = params['client_secret']
+        elif config.has_option('Web Services', 'clientsecret'):
             self.client_secret = config.get('Web Services', 'clientsecret')
         elif 'FUELSDK_CLIENT_SECRET' in os.environ:
             self.client_secret = os.environ['FUELSDK_CLIENT_SECRET']


### PR DESCRIPTION
I need to use the FuelSDK for several clients (Apps). This allows me to iterate over those separate App IDs. The use-case looks something like the following:

```
from ConfigParser import ConfigParser
import os
import FuelSDK

config = ConfigParser()
full_path = os.path.join(os.path.dirname(__file__), 'settings.ini')
config.read(full_path)
for s in config.sections():
    params = dict(config.items(s))
    client = FuelSDK.ET_Client(params = params)
```

I've emulated the existing check for JWT params.
