### PR TITLE
Allow newer versions of requests

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 PyJWT==0.1.9
 distribute==0.7.3
-requests==2.2.1
+requests>=2.2.1,<=2.5.0
 suds==0.4
 wsgiref==0.1.2


### PR DESCRIPTION
It looks like FuelSDK is using requests pretty generically, can we loosen the requirement to allow newer versions?

We need to use a newer version of requests in other parts of our application and this will prevent conflicts.  Should be helpful for folks in a similar situation, or who are looking to integrate another package which requires a newer version of requests.