### PR TITLE
Remove hardcoded version dependencies in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -15,9 +15,9 @@ setup(
     url='https://github.com/ExactTarget/FuelSDK-Python',
     license='MIT',
     install_requires=[
-        'pyjwt==0.1.9',
-        'requests==2.2.1',
-        'suds==0.4',
+        'pyjwt',
+        'requests',
+        'suds',
     ],
     classifiers=[
         'Development Status :: 5 - Production/Stable',


### PR DESCRIPTION
I'm a user of this SDK and I want to upgrade my version of pyjwt to the latest, 1.0.1, which addresses some nasty security vulnerabilities.

However, I can't, due to the hardcoded versions in setup.py. Removing these versions from setup.py lets downstream consumers of your library use whichever requirements they want, and is good practice. More discussion here if you're curious: https://caremad.io/2013/07/setup-vs-requirement/