### PR TITLE
Add new object query types

### DIFF
--- a/FuelSDK/objects.py
+++ b/FuelSDK/objects.py
@@ -87,15 +87,35 @@ class ET_ClickEvent(ET_GetSupport):
 ##  wrap an Exact Target List and List Subscriber
 ##
 ########
+class ET_Group(ET_CUDSupport):
+    def __init__(self):
+        super(ET_Group, self).__init__()
+        self.obj_type = 'Group'
+
+class ET_Send(ET_CUDSupport):
+    def __init__(self):
+        super(ET_Send, self).__init__()
+        self.obj_type = 'Send'
+
+class ET_ListSend(ET_CUDSupport):
+    def __init__(self):
+        super(ET_ListSend, self).__init__()
+        self.obj_type = 'ListSend'
+
 class ET_List(ET_CUDSupport):
     def __init__(self):
         super(ET_List, self).__init__()
         self.obj_type = 'List'
-    
+
 class ET_List_Subscriber(ET_GetSupport):
     def __init__(self):
         super(ET_List_Subscriber, self).__init__()
-        self.obj_type = 'ListSubscriber'    
+        self.obj_type = 'ListSubscriber'
+
+class ET_SubscriberList(ET_GetSupport):
+    def __init__(self):
+        super(ET_Subscriber_List, self).__init__()
+        self.obj_type = 'SubscriberList'
 
 class ET_SentEvent(ET_GetSupport):
     def __init__(self):


### PR DESCRIPTION
This adds the following types to `objects.py`
 - [ET_Group](http://help.exacttarget.com/en/technical_library/web_service_guide/objects/group/)
 - [ET_Send](http://help.exacttarget.com/en/technical_library/web_service_guide/objects/send/)
 - [ET_ListSend](http://help.exacttarget.com/en/technical_library/web_service_guide/objects/listsend/)
 - [ET_SubscriberList](http://help.exacttarget.com/en/technical_library/web_service_guide/objects/subscriberlist/)

The list of types we should be able to retrieve is [here](http://help.exacttarget.com/en/technical_library/web_service_guide/methods/retrieve/).