### PR TITLE
fixed requirements typo

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-p[]PyJWT>=1.4.0
+PyJWT>=1.4.0
 distribute==0.7.3
 requests>=2.10.0
 suds-jurko==0.6

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,5 +2,4 @@ PyJWT>=1.4.0
 distribute==0.7.3
 requests>=2.10.0
 suds-jurko==0.6
-wsgiref==0.1.2
 


### PR DESCRIPTION
A typo prevented parsing of the requirements file.
