### PR TITLE
has_key removed in python 3

### DIFF
--- a/FuelSDK/objects.py
+++ b/FuelSDK/objects.py
@@ -1,4 +1,4 @@
-from FuelSDK.rest import ET_CUDSupport,ET_CUDSupportRest,ET_GetSupport,ET_Get,ET_Patch,ET_Post,ET_Delete,ET_Configure
+from FuelSDK.rest import ET_CUDSupport,ET_CUDSupportRest,ET_GetSupport,ET_Get,ET_Patch,ET_Post,ET_Delete,ET_Configure,ET_Describe
 
 ########
 ##
@@ -36,6 +36,9 @@ class ET_ProfileAttribute():
         if obj is not None:
             self.last_request_id = obj.request_id
         return obj
+
+    def get(self):
+        return ET_Describe(self.auth_stub, 'Subscriber')
 
 ########
 ##

--- a/FuelSDK/rest.py
+++ b/FuelSDK/rest.py
@@ -213,7 +213,6 @@ class ET_Get(ET_Constructor):
 class ET_Post(ET_Constructor):
     def __init__(self, auth_stub, obj_type, props = None):
         auth_stub.refresh_token()
-        print("response")
         response = auth_stub.soap_client.service.Create(None, self.parse_props_into_ws_object(auth_stub, obj_type, props))
         if(response is not None):
             super(ET_Post, self).__init__(response)

--- a/FuelSDK/rest.py
+++ b/FuelSDK/rest.py
@@ -160,7 +160,7 @@ class ET_Get(ET_Constructor):
                 ws_retrieveRequest.Properties = props
 
         if search_filter is not None:
-            if search_filter.has_key('LogicalOperator'):
+            if 'LogicalOperator' in search_filter:
                 ws_simpleFilterPartLeft = auth_stub.soap_client.factory.create('SimpleFilterPart')
                 for prop in ws_simpleFilterPartLeft:
                     #print prop[0]


### PR DESCRIPTION
'key in dict' has existed for a long time and is much more pythonic;
accordingly, this change is backwards compatible.