### PR TITLE
Changed iteritems() to items() for Python3 support

### DIFF
--- a/FuelSDK/__init__.py
+++ b/FuelSDK/__init__.py
@@ -1,4 +1,4 @@
-__version__ = '0.9.3'
+__version__ = '1.0.0'
 
 # Runtime patch the suds library
 from FuelSDK.suds_patch import _PropertyAppender

--- a/FuelSDK/objects.py
+++ b/FuelSDK/objects.py
@@ -282,7 +282,7 @@ class ET_DataExtension_Row(ET_CUDSupport):
                 currentFields = []
                 currentProp = {}
                 
-                for key, value in rec.iteritems():
+                for key, value in rec.items():
                     currentFields.append({"Name" : key, "Value" : value})
                 
                 currentProp['CustomerKey'] = self.CustomerKey
@@ -297,7 +297,7 @@ class ET_DataExtension_Row(ET_CUDSupport):
             currentFields = []
             currentProp = {}
                 
-            for key, value in self.props.iteritems():
+            for key, value in self.props.items():
                 currentFields.append({"Name" : key, "Value" : value})
 
             currentProp['CustomerKey'] = self.CustomerKey
@@ -317,7 +317,7 @@ class ET_DataExtension_Row(ET_CUDSupport):
                 currentFields = []
                 currentProp = {}
                 
-                for key, value in rec.iteritems():
+                for key, value in rec.items():
                     currentFields.append({"Name" : key, "Value" : value})
                 
                 currentProp['CustomerKey'] = self.CustomerKey
@@ -331,7 +331,7 @@ class ET_DataExtension_Row(ET_CUDSupport):
             currentFields = []
             currentProp = {}
             
-            for key, value in self.props.iteritems():
+            for key, value in self.props.items():
                 currentFields.append({"Name" : key, "Value" : value})
             
             currentProp['CustomerKey'] = self.CustomerKey
@@ -350,7 +350,7 @@ class ET_DataExtension_Row(ET_CUDSupport):
                 currentFields = []
                 currentProp = {}
                 
-                for key, value in rec.iteritems():
+                for key, value in rec.items():
                     currentFields.append({"Name" : key, "Value" : value})
                 
                 currentProp['CustomerKey'] = self.CustomerKey
@@ -364,7 +364,7 @@ class ET_DataExtension_Row(ET_CUDSupport):
             currentFields = []
             currentProp = {}
                 
-            for key, value in self.props.iteritems():
+            for key, value in self.props.items():
                 currentFields.append({"Name" : key, "Value" : value})
     
             currentProp['CustomerKey'] = self.CustomerKey


### PR DESCRIPTION
Python3 version was still using iteritems()
I've changed it to items() for Python3 support
Bumped the version to 1.0.0