### PR TITLE
Fix readme typo for formatting

### DIFF
--- a/README.md
+++ b/README.md
@@ -222,7 +222,7 @@ if value is None:
 - Install Suds by running the command
 ```
 python setup.py install
-``
+```
 
 ## Copyright and license
 Copyright (c) 2017 Salesforce


### PR DESCRIPTION
Fix readme typo making it clearer where the copyright notice is at the bottom of the readme.