### PR TITLE
Make soap endpoint configurable and remove legacy flag

### DIFF
--- a/FuelSDK/client.py
+++ b/FuelSDK/client.py
@@ -166,8 +166,8 @@ class ET_Client(object):
         
 
     def build_soap_client(self):
-        if self.soap_endpoint is None:
-            self.soap_endpoint = self.determineStack()
+        if self.soap_endpoint is None or not self.soap_endpoint:
+            self.soap_endpoint = self.get_soap_endpoint()
 
         self.soap_client = suds.client.Client(self.wsdl_file_url, faults=False, cachingpolicy=1)
         self.soap_client.set_options(location=self.soap_endpoint)
@@ -217,17 +217,17 @@ class ET_Client(object):
 
         data = {}
         data['url'] = url
-        data['timestamp'] = time.time()
+        data['timestamp'] = time.time() + (10 * 60)
         json.dump(data, file)
         file.close()
 
-    def determineStack(self):
+    def get_soap_endpoint(self):
         default_endpoint = 'https://webservice.exacttarget.com/Service.asmx'
 
         cache_file_data = self.get_soap_cache_file()
 
         if 'url' in cache_file_data and 'timestamp' in cache_file_data \
-            and cache_file_data['timestamp'] + (15 * 60) > time.time():
+            and cache_file_data['timestamp'] > time.time():
             return cache_file_data['url']
 
         """

--- a/FuelSDK/client.py
+++ b/FuelSDK/client.py
@@ -7,7 +7,6 @@ import json
 import jwt
 import requests
 import suds.client
-import suds.wsse
 from suds.sax.element import Element
 
 
@@ -175,13 +174,6 @@ class ET_Client(object):
 
         element_fueloauth = Element('fueloauth').setText(self.authToken)
         self.soap_client.set_options(soapheaders=(element_fueloauth))
-        
-        # Commenting this for now, don't think we need to support it
-        # security = suds.wsse.Security()
-        # token = suds.wsse.UsernameToken('*', '*')
-        # security.tokens.append(token)
-        # self.soap_client.set_options(wsse=security)
-        
 
     def refresh_token(self, force_refresh = False):
         """

--- a/FuelSDK/client.py
+++ b/FuelSDK/client.py
@@ -209,24 +209,26 @@ class ET_Client(object):
                 self.refreshKey = tokenResponse['refreshToken']
         
             self.build_soap_client()
-            
 
     def determineStack(self):
+        default_endpoint = 'https://webservice.exacttarget.com/Service.asmx'
         """
         find the correct url that data request web calls should go against for the token we have.
         """
         try:
             r = requests.get(self.base_api_url + '/platform/v1/endpoints/soap', headers={
-                'user-agent' : 'FuelSDK-Python',
-                'authorization' : 'Bearer ' + self.authToken
+                'user-agent': 'FuelSDK-Python',
+                'authorization': 'Bearer ' + self.authToken
             })
+
             contextResponse = r.json()
-            if('url' in contextResponse):
+            if ('url' in contextResponse):
                 return str(contextResponse['url'])
+            else:
+                return default_endpoint
 
         except Exception as e:
-            raise Exception('Unable to determine stack using /platform/v1/endpoints/soap: ' + e.message)
-
+            return default_endpoint
 
     def AddSubscriberToList(self, emailAddress, listIDs, subscriberKey = None):
         """

--- a/FuelSDK/config.python.template
+++ b/FuelSDK/config.python.template
@@ -5,4 +5,5 @@ clientsecret: XXXXXXXXXXXXXXXXXXXXXXXX
 defaultwsdl: https://webservice.exacttarget.com/etframework.wsdl
 baseapiurl: https://www.exacttargetapis.com
 authenticationurl: https://auth.exacttargetapis.com/v1/requestToken
+soapendpoint: https://webservice.exacttarget.com/Service.asmx
 wsdl_file_local_loc: /tmp/ExactTargetWSDL.s6.xml

--- a/FuelSDK/config.python.template
+++ b/FuelSDK/config.python.template
@@ -4,5 +4,5 @@ clientid: XXXXXXXXXXXXXXXXXXXXXXXX
 clientsecret: XXXXXXXXXXXXXXXXXXXXXXXX
 defaultwsdl: https://webservice.exacttarget.com/etframework.wsdl
 baseapiurl: https://www.exacttargetapis.com
-authenticationurl: https://auth.exacttargetapis.com/v1/requestToken?legacy=1
+authenticationurl: https://auth.exacttargetapis.com/v1/requestToken
 wsdl_file_local_loc: /tmp/ExactTargetWSDL.s6.xml

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ You must configure your access tokens and details for the Fuel SDK in one of the
 Edit `config.python` or declare environment variables so you can input the ClientID and Client Secret values provided when you registered your application. If you are building a HubExchange application for the Interactive Marketing Hub then, you must also provide the Application Signature (`appsignature` / `FUELSDK_APP_SIGNATURE`).
 The `defaultwsdl` / `FUELSDK_DEFAULT_WSDL` configuration must be [changed depending on the Salesforce marketing cloud service](https://code.exacttarget.com/question/there-any-cetificrate-install-our-server-access-et-api "Salesforce Marketing Cloud Forum").
 The `baseapiurl` / `FUELSDK_BASE_API_URL` refers to the hostname where the API is hosted, if omitted it will default to [https://www.exacttargetapis.com](https://www.exacttargetapis.com).
-The `authenticationurl` / `FUELSDK_AUTH_URL` must also be [changed depending on service](https://code.exacttarget.com/question/not-able-create-accesstoken-when-clientidsecret-associated-preproduction-account "Salesforce Marketing Cloud Forum").
+The `authenticationurl` / `FUELSDK_AUTH_URL` must also be [changed depending on service](https://code.exacttarget.com/question/not-able-create-accesstoken-when-clientidsecret-associated-preproduction-account "Salesforce Marketing Cloud Forum"). If omitted it will default to [https://auth.exacttargetapis.com/v1/requestToken](https://auth.exacttargetapis.com/v1/requestToken).
 The `wsdl_file_local_loc` / `FUELSDK_WSDL_FILE_LOCAL_LOC` allows you to specify the full path/filename where the WSDL file will be located on disk, if for instance you are connecting to different endpoints from the same server.
 
 If you have not registered your application or you need to lookup your Application Key or Application Signature values, please go to App Center at [Code@: Salesforce Marketing Cloud's Developer Community](https://developer.salesforce.com/docs/?filter_text=&service=Marketing%20Cloud "Code@ App Center").
@@ -41,8 +41,8 @@ If you have not registered your application or you need to lookup your Applicati
 
 | Environment | WSDL (default) | URL (auth) |
 | ----------- | -------------- | ---------- |
-| Production  | https://webservice.exacttarget.com/etframework.wsdl | https://auth.exacttargetapis.com/v1/requestToken?legacy=1 |
-| Sandbox     | https://webservice.test.exacttarget.com/Service.asmx?wsdl | https://auth-test.exacttargetapis.com/v1/requestToken?legacy=1 |
+| Production  | https://webservice.exacttarget.com/etframework.wsdl | https://auth.exacttargetapis.com/v1/requestToken |
+| Sandbox     | https://webservice.test.exacttarget.com/Service.asmx?wsdl | https://auth-test.exacttargetapis.com/v1/requestToken |
 
 
 ## Example Request

--- a/README.md
+++ b/README.md
@@ -35,7 +35,8 @@ Edit `config.python` or declare environment variables so you can input the Clien
 The `defaultwsdl` / `FUELSDK_DEFAULT_WSDL` configuration must be [changed depending on the Salesforce marketing cloud service](https://code.exacttarget.com/question/there-any-cetificrate-install-our-server-access-et-api "Salesforce Marketing Cloud Forum").
 The `baseapiurl` / `FUELSDK_BASE_API_URL` refers to the hostname where the API is hosted, if omitted it will default to [https://www.exacttargetapis.com](https://www.exacttargetapis.com).
 The `authenticationurl` / `FUELSDK_AUTH_URL` must also be [changed depending on service](https://code.exacttarget.com/question/not-able-create-accesstoken-when-clientidsecret-associated-preproduction-account "Salesforce Marketing Cloud Forum"). If omitted it will default to [https://auth.exacttargetapis.com/v1/requestToken](https://auth.exacttargetapis.com/v1/requestToken).
-The `soapendpoint` / `FUELSDK_SOAP_ENDPOINT` refers to the endpoint that will be used for doing SOAP calls.
+The `soapendpoint` / `FUELSDK_SOAP_ENDPOINT` refers to the endpoint that will be used for doing SOAP calls. If omitted it is calculated by calling the `/platform/v1/endpoints/soap` endpoint. If the HTTP call fails, it will default to [https://webservice.exacttarget.com/Service.asmx](https://webservice.exacttarget.com/Service.asmx).
+
 The `wsdl_file_local_loc` / `FUELSDK_WSDL_FILE_LOCAL_LOC` allows you to specify the full path/filename where the WSDL file will be located on disk, if for instance you are connecting to different endpoints from the same server.
 
 If you have not registered your application or you need to lookup your Application Key or Application Signature values, please go to App Center at [Code@: Salesforce Marketing Cloud's Developer Community](https://developer.salesforce.com/docs/?filter_text=&service=Marketing%20Cloud "Code@ App Center").

--- a/README.md
+++ b/README.md
@@ -28,12 +28,14 @@ You must configure your access tokens and details for the Fuel SDK in one of the
     * `FUELSDK_DEFAULT_WSDL`
     * `FUELSDK_BASE_API_URL`
     * `FUELSDK_AUTH_URL`
+    * `FUELSDK_SOAP_ENDPOINT`
     * `FUELSDK_WSDL_FILE_LOCAL_LOC`
 
 Edit `config.python` or declare environment variables so you can input the ClientID and Client Secret values provided when you registered your application. If you are building a HubExchange application for the Interactive Marketing Hub then, you must also provide the Application Signature (`appsignature` / `FUELSDK_APP_SIGNATURE`).
 The `defaultwsdl` / `FUELSDK_DEFAULT_WSDL` configuration must be [changed depending on the Salesforce marketing cloud service](https://code.exacttarget.com/question/there-any-cetificrate-install-our-server-access-et-api "Salesforce Marketing Cloud Forum").
 The `baseapiurl` / `FUELSDK_BASE_API_URL` refers to the hostname where the API is hosted, if omitted it will default to [https://www.exacttargetapis.com](https://www.exacttargetapis.com).
 The `authenticationurl` / `FUELSDK_AUTH_URL` must also be [changed depending on service](https://code.exacttarget.com/question/not-able-create-accesstoken-when-clientidsecret-associated-preproduction-account "Salesforce Marketing Cloud Forum"). If omitted it will default to [https://auth.exacttargetapis.com/v1/requestToken](https://auth.exacttargetapis.com/v1/requestToken).
+The `soapendpoint` / `FUELSDK_SOAP_ENDPOINT` refers to the endpoint that will be used for doing SOAP calls.
 The `wsdl_file_local_loc` / `FUELSDK_WSDL_FILE_LOCAL_LOC` allows you to specify the full path/filename where the WSDL file will be located on disk, if for instance you are connecting to different endpoints from the same server.
 
 If you have not registered your application or you need to lookup your Application Key or Application Signature values, please go to App Center at [Code@: Salesforce Marketing Cloud's Developer Community](https://developer.salesforce.com/docs/?filter_text=&service=Marketing%20Cloud "Code@ App Center").


### PR DESCRIPTION
[W-5497231](https://gus.lightning.force.com/lightning/r/ADM_Work__c/a07B0000005b1E4IAI/view): Phyton - Auth, Rest and SOAP endpoints should be made configurable
[W-5500244](https://gus.lightning.force.com/lightning/r/ADM_Work__c/a07B0000005b3smIAA/view): Python - Remove the legacyToken query string parameter support from all SDKs
[W-5500256](https://gus.lightning.force.com/lightning/r/ADM_Work__c/a07B0000005b3tkIAA/view): Python - Cache the SOAP endpoint for 15 minutes

Work done:

- Made SOAP endpoint configurable
- Add  a default value for soap_endpoint when call to /endpoints/soap fails
- Add caching for /endpoints/soap call
- Remove legacy flag
- Update SOAP header to send <fueloauth> tag
- Update README.md