### PR TITLE
Catch Exception from JSONDecodeError

### DIFF
--- a/FuelSDK/client.py
+++ b/FuelSDK/client.py
@@ -363,12 +363,12 @@ class ET_Client(object):
         json_data = {}
         
         try:
-	        if os.path.isfile(self.soap_cache_file):
-	            file = open(self.soap_cache_file, "r")
-	            json_data = json.load(file)
-	            file.close()
-	    except Exception:
-	    	return json_data
+            if os.path.isfile(self.soap_cache_file):
+                file = open(self.soap_cache_file, "r")
+                json_data = json.load(file)
+                file.close()
+        except Exception:
+            return json_data
 
         return json_data
 

--- a/FuelSDK/client.py
+++ b/FuelSDK/client.py
@@ -380,16 +380,17 @@ class ET_Client(object):
     def get_soap_endpoint(self):
         default_endpoint = 'https://webservice.exacttarget.com/Service.asmx'
 
-        cache_file_data = self.get_soap_cache_file()
-
-        if 'url' in cache_file_data and 'timestamp' in cache_file_data \
-            and cache_file_data['timestamp'] > time.time():
-            return cache_file_data['url']
-
-        """
-        find the correct url that data request web calls should go against for the token we have.
-        """
         try:
+        	cache_file_data = self.get_soap_cache_file()
+
+	        if 'url' in cache_file_data and 'timestamp' in cache_file_data \
+	            and cache_file_data['timestamp'] > time.time():
+	            return cache_file_data['url']
+
+	        """
+	        find the correct url that data request web calls should go against for the token we have.
+	        """
+        
             r = requests.get(self.base_api_url + '/platform/v1/endpoints/soap', headers={
                 'user-agent': 'FuelSDK-Python-v1.3.0',
                 'authorization': 'Bearer ' + self.authToken

--- a/FuelSDK/client.py
+++ b/FuelSDK/client.py
@@ -361,10 +361,14 @@ class ET_Client(object):
 
     def get_soap_cache_file(self):
         json_data = {}
-        if os.path.isfile(self.soap_cache_file):
-            file = open(self.soap_cache_file, "r")
-            json_data = json.load(file)
-            file.close()
+        
+        try:
+	        if os.path.isfile(self.soap_cache_file):
+	            file = open(self.soap_cache_file, "r")
+	            json_data = json.load(file)
+	            file.close()
+	    except Exception:
+	    	return json_data
 
         return json_data
 
@@ -380,17 +384,16 @@ class ET_Client(object):
     def get_soap_endpoint(self):
         default_endpoint = 'https://webservice.exacttarget.com/Service.asmx'
 
+        cache_file_data = self.get_soap_cache_file()
+
+        if 'url' in cache_file_data and 'timestamp' in cache_file_data \
+            and cache_file_data['timestamp'] > time.time():
+            return cache_file_data['url']
+
+        """
+        find the correct url that data request web calls should go against for the token we have.
+        """
         try:
-        	cache_file_data = self.get_soap_cache_file()
-
-	        if 'url' in cache_file_data and 'timestamp' in cache_file_data \
-	            and cache_file_data['timestamp'] > time.time():
-	            return cache_file_data['url']
-
-	        """
-	        find the correct url that data request web calls should go against for the token we have.
-	        """
-        
             r = requests.get(self.base_api_url + '/platform/v1/endpoints/soap', headers={
                 'user-agent': 'FuelSDK-Python-v1.3.0',
                 'authorization': 'Bearer ' + self.authToken

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # FuelSDK-Python v1.3.0
 
-Salesforce Marketing Cloud Fuel SDK for Python
+Feverup's fork of Salesforce Marketing Cloud Fuel SDK for Python
 
 ## Overview
 

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ with open('README.md') as f:
     readme = f.read()
 
 setup(
-    version='1.3.0',
+    version='1.3.1',
     name='Salesforce-FuelSDK',
     description='Salesforce Marketing Cloud Fuel SDK for Python',
     long_description=readme,

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ setup(
     description='Fever Salesforce Marketing Cloud Fuel SDK for Python',
     long_description=readme,
     long_description_content_type="text/markdown",
-    author='ExactTarget',
+    author='Feverup',
     py_modules=['ET_Client'],
     packages=['FuelSDK'],
     url='https://github.com/Feverup/FuelSDK-Python',

--- a/setup.py
+++ b/setup.py
@@ -5,14 +5,14 @@ with open('README.md') as f:
 
 setup(
     version='1.3.1',
-    name='Salesforce-FuelSDK',
-    description='Salesforce Marketing Cloud Fuel SDK for Python',
+    name='Fever-FuelSDK',
+    description='Fever Salesforce Marketing Cloud Fuel SDK for Python',
     long_description=readme,
     long_description_content_type="text/markdown",
     author='ExactTarget',
     py_modules=['ET_Client'],
     packages=['FuelSDK'],
-    url='https://github.com/salesforce-marketingcloud/FuelSDK-Python',
+    url='https://github.com/Feverup/FuelSDK-Python',
     license='MIT',
     install_requires=[
         'pyjwt>=1.5.3',


### PR DESCRIPTION
Eventually, without too much reasoning, the JSON saved as cache on the local file get a double }}, if that happens, every call to the SDK will fail with a JSONDecodeError

![image](https://user-images.githubusercontent.com/3419188/102374839-185ebf80-3fc2-11eb-8791-7d21aa2d881f.png)

This handles the JSON error inside the try/except so it will try to fetch the proper URL again